### PR TITLE
INTERP_BICUBIC instead of INTERP_BILINEAR

### DIFF
--- a/lightcrafts/src/com/lightcrafts/jai/utils/Functions.java
+++ b/lightcrafts/src/com/lightcrafts/jai/utils/Functions.java
@@ -70,7 +70,7 @@ public class Functions {
         RenderingHints extenderHints = new RenderingHints(JAI.KEY_BORDER_EXTENDER,
                                                   BorderExtender.createInstance(BorderExtender.BORDER_COPY));
 
-        // Interpolation interp = Interpolation.getInstance(Interpolation.INTERP_BILINEAR);
+        Interpolation interp = Interpolation.getInstance(Interpolation.INTERP_BICUBIC);
 
         RenderedImage scaleDown;
         if (rescale != 1) {
@@ -91,7 +91,7 @@ public class Functions {
             pb.addSource(blur);
             pb.add(AffineTransform.getScaleInstance(image.getWidth() / (double) blur.getWidth(),
                                                     image.getHeight() / (double) blur.getHeight()));
-            // pb.add(interp);
+            pb.add(interp);
             RenderingHints sourceLayoutHints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT,
                                                                   new ImageLayout(0, 0,
                                                                                   JAIContext.TILE_WIDTH,


### PR DESCRIPTION
More suitable fix for the issue #23 (line artifacts, only on linux with native mediaLib):

INTERP_BILINEAR causes the bug here, though with INTERP_BICUBIC_2, INTERP_BICUBIC or INTERP_NEAREST there is no problem. I think it is better to use one of latter methods than just commenting out.
