### PR TITLE
Fix for "region tools" and "cropping" bugs

### DIFF
--- a/lightcrafts/src/com/lightcrafts/model/ImageEditor/Rendering.java
+++ b/lightcrafts/src/com/lightcrafts/model/ImageEditor/Rendering.java
@@ -383,6 +383,7 @@ public class Rendering implements Cloneable {
                     level++;
                 }
                 image = (PlanarImage) pyramid.getImage(level);
+                transform = new AffineTransform(transform);
                 transform.concatenate(AffineTransform.getScaleInstance(sourceImage.getWidth() / (double)image.getWidth(),
                                                                        sourceImage.getHeight() / (double)image.getHeight()));
             }


### PR DESCRIPTION
Fix for a bug with region tools that had reported by RebertoQ.
Without this line, a region's effect appears in wrong size and position on a image.

Edit:
It seems that this commit also fixes the cropping bug reported by Jedd, in which a scaled image won't be displayed properly in 'FIT' mode.
