### PR TITLE
Linux -  Changed license to BSD 3-clause in lightzone.spec

### DIFF
--- a/linux/lightzone.changes
+++ b/linux/lightzone.changes
@@ -1,10 +1,15 @@
 -------------------------------------------------------------------
-Mon May 20 2013 - KITAGAW Masahiro <arctica0316@gmail.com>
+Mon Jun 17 2013 - KITAGAWA Masahiro <arctica0316@gmail.com>
+
+- Changed license to BSD 3-clause Licence
+
+-------------------------------------------------------------------
+Mon May 20 2013 - KITAGAWA Masahiro <arctica0316@gmail.com>
 
 - Fixed rpmlint warnings
 
 -------------------------------------------------------------------
-Sat May 11 2013 - KITAGAW Masahiro <arctica0316@gmail.com>
+Sat May 11 2013 - KITAGAWA Masahiro <arctica0316@gmail.com>
 
 - Changes for openSuse Build Service cross platform build
 - Divided changelog section from .spec into .changes

--- a/linux/lightzone.spec
+++ b/linux/lightzone.spec
@@ -5,7 +5,7 @@
 Name:           lightzone
 Version:	4.0.0
 Release:	1
-License:	GPL-2.0+
+License:	BSD-3-Clause
 Summary:	Open-source professional-level digital darkroom software
 Url:		http://lightzoneproject.org/
 Group:		Productivity/Graphics/Convertors 


### PR DESCRIPTION
linux/lightzone.spec says that license is GPL 2.0+, but it should be BSD 3-clause.
