### PR TITLE
Styles for old Channel Mixer, High-Pass Filter, and Tone Mapper tools

### DIFF
--- a/lightcrafts/resources/com/lightcrafts/templates/resources/Black & White;Channel Mixer.lzt
+++ b/lightcrafts/resources/com/lightcrafts/templates/resources/Black & White;Channel Mixer.lzt
@@ -1,0 +1,13 @@
+<Template version="7">
+  <Scale Factor="0.23936696"/>
+  <Image path=""/>
+  <Controls>
+    <GenericOperation Active="true" Collapsed="false" Locked="false" Mode="Normal" Name="Channel Mixer" Opacity="100" OperationType="Channel Mixer" regionsInverted="false">
+      <Slider Blue="0.0722" Green="0.7152" Red="0.2126"/>
+      <Checkbox/>
+      <Choice/>
+    </GenericOperation>
+    <Region/>
+    <Crop Angle="0.0"/>
+  </Controls>
+</Template>

--- a/lightcrafts/resources/com/lightcrafts/templates/resources/Detail Enhancement;High-Pass Filter.lzt
+++ b/lightcrafts/resources/com/lightcrafts/templates/resources/Detail Enhancement;High-Pass Filter.lzt
@@ -1,0 +1,14 @@
+<Template version="6">
+  <Scale Factor="0.5024414"/>
+  <Image path=""/>
+  <Controls>
+    <GenericOperation Active="true" Collapsed="false" Locked="false" Mode="Midtones" Name="High-Pass Filter" Opacity="100" OperationType="Hi Pass Filter" layerControlsIndex="0" regionsInverted="false">
+      <Slider Gain="0.05" Radius="0.60"/>
+      <Checkbox/>
+      <Choice/>
+      <Color b="128" g="128" r="128"/>
+    </GenericOperation>
+    <Region/>
+    <Crop/>
+  </Controls>
+</Template>

--- a/lightcrafts/resources/com/lightcrafts/templates/resources/High Contrast;Tone Mapper.lzt
+++ b/lightcrafts/resources/com/lightcrafts/templates/resources/High Contrast;Tone Mapper.lzt
@@ -1,0 +1,13 @@
+<Template version="7">
+  <Scale Factor="0.23936696"/>
+  <Image path=""/>
+  <Controls>
+    <GenericOperation Active="true" Collapsed="false" Locked="false" Mode="Soft Light" Name="Tone Mapper" Opacity="75" OperationType="Tone Mapper" regionsInverted="false">
+      <Slider Detail="0.8" Gamma="2.2" Radius="250.0"/>
+      <Checkbox/>
+      <Choice/>
+    </GenericOperation>
+    <Region/>
+    <Crop Angle="0.0"/>
+  </Controls>
+</Template>

--- a/lightcrafts/resources/com/lightcrafts/templates/resources/TemplateList
+++ b/lightcrafts/resources/com/lightcrafts/templates/resources/TemplateList
@@ -1,11 +1,13 @@
 Black & White;Alien Infrared.lzt
 Black & White;Blue Filter.lzt
+Black & White;Channel Mixer.lzt
 Black & White;High Key Portrait.lzt
 Black & White;Infrared.lzt
 Black & White;Normal.lzt
 Black & White;Red Filter.lzt
 Black & White;Soft Skin Tones.lzt
 Black & White;Yellow Filter.lzt
+Detail Enhancement;High-Pass Filter.lzt
 Detail Enhancement;Local Contrast.lzt
 Detail Enhancement;SLR Sharpen.lzt
 Effects;Clarity II.lzt
@@ -20,6 +22,7 @@ Effects;Soften Skin.lzt
 High Contrast;Polarizer.lzt
 High Contrast;Soft Wow! 2.lzt
 High Contrast;Soft Wow!.lzt
+High Contrast;Tone Mapper.lzt
 High Contrast;Wow!.lzt
 High Dynamic Range;Bright Scene.lzt
 High Dynamic Range;Dark Scene.lzt


### PR DESCRIPTION
This pull request adds three built-in templates (styles) that allow access to LightZone tools that otherwise can't be accessed.
