### PR TITLE
Fixed #48 (Recognize newer backs (H25, IQ140, P20+) in Phase One probe)

### DIFF
--- a/lightcrafts/src/com/lightcrafts/image/types/PhaseOneTIFFRawImageProbe.java
+++ b/lightcrafts/src/com/lightcrafts/image/types/PhaseOneTIFFRawImageProbe.java
@@ -30,7 +30,13 @@ final class PhaseOneTIFFRawImageProbe implements TrueImageTypeProvider {
         final LCByteBuffer buf = imageInfo.getByteBuffer();
         try {
             buf.position( 12 );
-            if ( buf.getEquals( "Raw", "ASCII" ) ) {
+            boolean isRaw = buf.getEquals("Raw", "ASCII");
+            if (! isRaw)
+            {
+                buf.position( 13 );
+                isRaw = buf.getEquals("waR", "ASCII");
+            }
+            if (isRaw) {
                 final ImageMetadata metadata = imageInfo.getCurrentMetadata();
                 MetadataUtil.removePreviewMetadataFrom( metadata );
                 MetadataUtil.removeWidthHeightFrom( metadata );


### PR DESCRIPTION
Fixes #48. Added code to recognize "waR" in position 13 of a TIFF file as being Phase One RAW, in addition to existing check for "Raw" in position 12.
