### PR TITLE
Linux - Fixed liblzma.so dependency conflict on Fedora

### DIFF
--- a/linux/lightzone.spec
+++ b/linux/lightzone.spec
@@ -33,7 +33,11 @@ BuildRequires: java-1.6.0-openjdk-devel, libX11-devel, liblzma5
 BuildRequires: java-1.6.0-openjdk-devel, libX11-devel, liblzma5
 %endif
 
+%if 0%{?fedora}
+Requires:	java >= 1.6.0, xz-libs
+%else
 Requires:	java >= 1.6.0, liblzma5
+%endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %description
 LightZone is open-source professional-level digital darkroom software for Windows, Mac OS X, and Linux. Rather than using layers as many other photo editors do, LightZone lets the user build up a stack of tools which can be rearranged, turned off and on, and removed from the stack. It's a non-destructive editor, where any of the tools can be re-adjusted or modified later — even in a different editing session. A tool stack can be copied to a batch of photos at one time. LightZone operates in a 16-bit linear color space with the wide gamut of ProPhoto RGB.


### PR DESCRIPTION
Fedora 18 fails to install Lightzone 4.0.0 with following error message:

```
Transaction Check Error:
file /usr/lib/liblzma.so.5 from install of liblzma5-5.0.4-1.1.i686 conflicts with file from package xz-libs-5.1.2-2alpha.fc18.i686
```

Issue is reported in http://lightzombie.org/comment/1452

LZ should depend on xz-libs in fedora, because liblzma5 is not a official package from fedora project but is from OpenSUSE.
