### PR TITLE
Fuji X100S Raw: Don't assume color filter array repeats every two rows

### DIFF
--- a/lightcrafts/src/com/lightcrafts/utils/DCRaw.java
+++ b/lightcrafts/src/com/lightcrafts/utils/DCRaw.java
@@ -367,7 +367,9 @@ public final class DCRaw implements
                         m_rawColors = Integer.decode(rawColors);
                     } else if (line.startsWith(search = FILTER_PATTERN)) {
                         String pattern = line.substring(search.length());
-                        if (pattern.startsWith("BGGR"))
+                        if (pattern.length() >= 8 && !pattern.substring(0,4).equals(pattern.substring(4,4)))
+                            m_filters = -1;
+                        else if (pattern.startsWith("BGGR"))
                             m_filters = 0x16161616;
                         else if (pattern.startsWith("GRBG"))
                             m_filters = 0x61616161;


### PR DESCRIPTION
The filter pattern reported by dcraw for the Fuji X100S starts with RGGB, and LightZone was erroneously assuming that meant a repeating pattern of RGGB, causing Fuji X100S Raw files to convert with wrong colors.
