### PR TITLE
Fixed metadata disappearing issue (#76)

### DIFF
--- a/lightcrafts/src/com/lightcrafts/image/metadata/XMPMetadataReader.java
+++ b/lightcrafts/src/com/lightcrafts/image/metadata/XMPMetadataReader.java
@@ -113,7 +113,11 @@ public final class XMPMetadataReader {
                                ImageMetadataDirectory dir ) {
         for ( Node node : elements ) {
             final Element dirElement = (Element)node;
-            final String tagName = dirElement.getLocalName();
+            //
+            // Use getTagName() since getLocalName() always returns null.
+            //
+            // final String tagName = dirElement.getLocalName();
+            final String tagName = dirElement.getTagName().replaceAll( ".*:", "" );
             final ImageMetaTagInfo tagInfo = dir.getTagInfoFor( tagName );
             if ( tagInfo == null )
                 continue;

--- a/lightcrafts/src/com/lightcrafts/utils/xml/ElementPrefixFilter.java
+++ b/lightcrafts/src/com/lightcrafts/utils/xml/ElementPrefixFilter.java
@@ -32,7 +32,11 @@ public class ElementPrefixFilter extends NodeTypeFilter {
         if ( !super.accept( node ) )
             return false;
         final Element element = (Element)node;
-        return m_prefix.equals( element.getPrefix() );
+        //
+        // Use getTagName() since getPrefix() always returns null.
+        //
+        // return m_prefix.equals( element.getPrefix() );
+        return m_prefix.equals( element.getTagName().replaceAll( ":.*", "" ) );
     }
 
     /**


### PR DESCRIPTION
Fixed #76.

Cause of the issue:
After reading metadata from files, XML parser didn't get tag names properly.
