### PR TITLE
Fixed wrong ISO speed shown in some Canon cr2 files (#34)

### DIFF
--- a/lightcrafts/src/com/lightcrafts/image/metadata/makernotes/CanonDirectory.java
+++ b/lightcrafts/src/com/lightcrafts/image/metadata/makernotes/CanonDirectory.java
@@ -100,11 +100,15 @@ public final class CanonDirectory extends MakerNotesDirectory implements
      * {@inheritDoc}
      */
     public int getISO() {
-        boolean isAPEX = false;
-        ImageMetaValue value = getValue( CANON_CS_ISO );
+        ImageMetaValue value = getValue( CANON_SI_ISO );
+        boolean isAPEX = true;
         if ( value == null ) {
-            value = getValue( CANON_SI_ISO );
-            isAPEX = true;
+            //
+            // CANON_CS_ISO can be "Auto" that is not a number,
+            // therefore it shouldn't be a default choice. 
+            //
+            value = getValue( CANON_CS_ISO );
+            isAPEX = false;
         }
         if ( value == null )
             return 0;


### PR DESCRIPTION
Fixed #34.
Sometimes CANON_CS_ISO tag is not numeric but string like "Auto", so we should use CANON_SI_ISO as a default.
