### PR TITLE
Issue88

### DIFF
--- a/lightcrafts/src/com/lightcrafts/model/ImageEditor/Rendering.java
+++ b/lightcrafts/src/com/lightcrafts/model/ImageEditor/Rendering.java
@@ -394,8 +394,9 @@ public class Rendering implements Cloneable {
                 ParameterBlock params = new ParameterBlock();
                 params.addSource(image);
                 params.add(transform);
-                // Note: never use INTERP_BICUBIC here, it causes color artifacts on over-exposed area in RAW files in pure Java mode JAI.
-                params.add(Interpolation.getInstance(cheapScale ? Interpolation.INTERP_NEAREST : Interpolation.INTERP_BILINEAR));
+                // Note: never use INTERP_BICUBIC nor INTERP_BILINEAR here,
+                // they cause color artifacts on over-exposed area in RAW files in pure Java mode JAI.
+                params.add(Interpolation.getInstance(Interpolation.INTERP_NEAREST));
                 xformedSourceImage = JAI.create("Affine", params, extenderHints);
             } else
                 xformedSourceImage = image;


### PR DESCRIPTION
Fixed #88 : Artifacts in overexposed areas.

In Rendering.java, INTERP_BICUBIC (or INTERP_BICUBIC_2) in pure Java mode JAI cause the color artifacts. We should use INTERP_BILINEAR there.

EDIT: I noticed that even the INTERP_BILINEAR caused artifact in another color on Windows, so I switched to INTERP_NEAREST.
