### PR TITLE
[Features] Adding additional overlay under cropping mode

### DIFF
--- a/lightcrafts/src/com/lightcrafts/ui/crop/CropMode.java
+++ b/lightcrafts/src/com/lightcrafts/ui/crop/CropMode.java
@@ -4,6 +4,7 @@ package com.lightcrafts.ui.crop;
 
 import com.lightcrafts.model.CropBounds;
 import com.lightcrafts.ui.mode.AbstractMode;
+import com.lightcrafts.ui.crop.CropOverlay;
 
 import javax.swing.*;
 import javax.swing.event.MouseInputListener;
@@ -59,6 +60,16 @@ public class CropMode extends AbstractMode {
             KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
             JComponent.WHEN_IN_FOCUSED_WINDOW
         );
+        overlay.registerKeyboardAction(
+            new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    overlay.changeOrientation();
+                }
+            },
+            KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0),
+            JComponent.WHEN_IN_FOCUSED_WINDOW
+        );
+
     }
 
     public void enter() {


### PR DESCRIPTION
This change adds 5 types of crop overlays (Rule of Third, Golden Triangles, Golden Ratio, Fibonacci Spiral, and Diagonal). Some notes below:
1. Using mouse click in crop mode to toggle different overlays 
2. Space key to switch to different orientations for golden triangle and Fibonacci spiral.
3. There are 8 different possible orientations for Fibonacci spiral. I only implement 4 at the moment. I think the spiral really doesn't make sense to go with shorter side of the image. Right now it works fine with landscape mode but portrait mode will have this issue. This is potentially a future improvement item.