### PR TITLE
Fixing fast_log2 early return bug.

### DIFF
--- a/lightcrafts/jnisrc/include/mathlz.h
+++ b/lightcrafts/jnisrc/include/mathlz.h
@@ -68,7 +68,6 @@ static inline float fast_log2 (float val)
     x += 127 << 23;
     *exp_ptr = x;
 
-    return (val + log_2);
     // increases accuracy
 #ifdef FP_FAST_FMAF
     val = fmaf((fmaf(-1.0f/3), n.f, 2), n.f, -2.0f/3);


### PR DESCRIPTION
This code seems to be wrong though I can't find a use case to show any significant differences of this correction. I have tested this routine in C++ so should be good.