### PR TITLE
Support Panasonic lens type in RW2 and JPG

### DIFF
--- a/lightcrafts/locale/com/lightcrafts/image/metadata/makernotes/PanasonicTags.properties
+++ b/lightcrafts/locale/com/lightcrafts/image/metadata/makernotes/PanasonicTags.properties
@@ -123,4 +123,6 @@
 0032>0=normal
 0032>1=natural
 
+0051=Lens type
+
 # vim:set et sw=4 ts=4:

--- a/lightcrafts/src/com/lightcrafts/image/metadata/EXIFMetadataReader.java
+++ b/lightcrafts/src/com/lightcrafts/image/metadata/EXIFMetadataReader.java
@@ -121,6 +121,9 @@ public class EXIFMetadataReader extends ImageMetadataReader
                 // TODO: handle this case
                 return;
             case EXIF_MAKER_NOTE:
+                // at this point, m_metadata only contains placeholder data
+		// in order to be able to determine makernote class, we need to merge or rework this code to use `dir`
+                mergeEXIFDirectories();
                 final Class<? extends MakerNotesDirectory> notesClass =
                     MakerNoteProbe.determineMakerNotesFrom( m_metadata );
                 if ( notesClass != null ) {

--- a/lightcrafts/src/com/lightcrafts/image/metadata/TIFFMetadataReader.java
+++ b/lightcrafts/src/com/lightcrafts/image/metadata/TIFFMetadataReader.java
@@ -3,15 +3,20 @@
 package com.lightcrafts.image.metadata;
 
 import java.io.IOException;
+import java.io.File;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.*;
 
 import com.lightcrafts.image.BadImageFileException;
+import com.lightcrafts.image.UnknownImageTypeException;
 import com.lightcrafts.image.ImageInfo;
 import com.lightcrafts.image.metadata.values.*;
+import com.lightcrafts.image.metadata.ImageMetadata;
 import com.lightcrafts.image.types.TIFFImageType;
 import com.lightcrafts.utils.Rational;
 import com.lightcrafts.utils.bytebuffer.ArrayByteBuffer;
+import com.lightcrafts.utils.bytebuffer.ByteBufferUtil;
 import com.lightcrafts.utils.bytebuffer.LCByteBuffer;
 
 import static com.lightcrafts.image.metadata.ImageMetadataConstants.*;
@@ -427,6 +432,22 @@ public class TIFFMetadataReader extends ImageMetadataReader {
                     m_metadata.getDirectoryFor( EXIFDirectory.class, true );
                 reader.readDirectory( subdirOffset, 0, exifDir );
                 return;
+            }
+            case TIFF_PANASONIC_JPEG_THUMBNAIL: {
+                ByteBuffer jpegBuffer = ByteBuffer.wrap( m_buf.getBytes(valueOffset, byteCount) );
+                File tmpFile = File.createTempFile("LCEmbeddedThumb", ".jpg");
+                String tmpName = tmpFile.getAbsolutePath();
+                ByteBufferUtil.dumpToFile(jpegBuffer, tmpName);
+                try {
+                        m_metadata.mergeFrom(ImageInfo.getInstanceFor( tmpFile ).getMetadata());
+                }
+                catch ( BadImageFileException e ) {
+                        logBadImageMetadata( "Processing embedded thumbnail's metadata threw a BadImageFileException" );
+                }
+                catch ( UnknownImageTypeException e ) {
+                        logBadImageMetadata( "Processing embedded thumbnail's metadata threw a UnknownImageTypeException" );
+                }
+                tmpFile.delete();
             }
             case TIFF_GPS_IFD_POINTER: {
                 final ImageMetadataDirectory gpsDir =

--- a/lightcrafts/src/com/lightcrafts/image/metadata/TIFFTags.java
+++ b/lightcrafts/src/com/lightcrafts/image/metadata/TIFFTags.java
@@ -1066,6 +1066,13 @@ public interface TIFFTags extends ImageMetaTags {
     int TIFF_ORIENTATION                    = 0x0112;
 
     /**
+     * The address of an embedded JPEG thumbnail in Panasonic cameras.
+     * <p>
+     * Type: Undefined.
+     */
+    int TIFF_PANASONIC_JPEG_THUMBNAIL       = 0x002E;
+
+    /**
      * The name of the page from which this image was scanned.
      * <p>
      * Type: ASCII.

--- a/lightcrafts/src/com/lightcrafts/image/metadata/makernotes/PanasonicDirectory.java
+++ b/lightcrafts/src/com/lightcrafts/image/metadata/makernotes/PanasonicDirectory.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
 import com.lightcrafts.image.metadata.*;
+import com.lightcrafts.image.metadata.providers.LensProvider;
 import com.lightcrafts.image.metadata.providers.OrientationProvider;
 import com.lightcrafts.image.metadata.values.*;
 import com.lightcrafts.utils.bytebuffer.LCByteBuffer;
@@ -23,9 +24,17 @@ import static com.lightcrafts.image.metadata.makernotes.PanasonicTags.*;
  */
 @SuppressWarnings({"CloneableClassWithoutClone"})
 public final class PanasonicDirectory extends MakerNotesDirectory implements
-    OrientationProvider {
+    LensProvider, OrientationProvider {
 
     ////////// public /////////////////////////////////////////////////////////
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getLens() {
+        final ImageMetaValue value = getValue( PANASONIC_LENS_TYPE );
+        return value.getStringValue();
+    }
 
     /**
      * Gets the maker-notes adjustments for Panasonic.
@@ -235,6 +244,7 @@ public final class PanasonicDirectory extends MakerNotesDirectory implements
         add( PANASONIC_IMAGE_QUALITY, "ImageQuality", META_USHORT );
         add( PANASONIC_IMAGE_STABILIZER, "ImageStabilizer", META_USHORT );
         add( PANASONIC_INTERNAL_SERIAL_NUMBER, "InternalSerialNumber", META_UNDEFINED );
+        add( PANASONIC_LENS_TYPE, "LensType", META_STRING );
         add( PANASONIC_MACRO_MODE, "MacroMode", META_USHORT );
         add( PANASONIC_NOISE_REDUCTION, "NoiseReduction", META_USHORT );
         add( PANASONIC_ROTATION, "Rotation", META_USHORT );

--- a/lightcrafts/src/com/lightcrafts/image/metadata/makernotes/PanasonicDirectory.java
+++ b/lightcrafts/src/com/lightcrafts/image/metadata/makernotes/PanasonicDirectory.java
@@ -50,7 +50,7 @@ public final class PanasonicDirectory extends MakerNotesDirectory implements
         //      0- 8: "Panasonic"
         //      9-11: 0 0 0
         //
-        return new int[]{ 12, offset };
+        return new int[]{ 12, 0 };
     }
 
     /**

--- a/lightcrafts/src/com/lightcrafts/image/metadata/makernotes/PanasonicTags.java
+++ b/lightcrafts/src/com/lightcrafts/image/metadata/makernotes/PanasonicTags.java
@@ -192,6 +192,13 @@ public interface PanasonicTags extends ImageMetaTags {
     int PANASONIC_INTERNAL_SERIAL_NUMBER    = 0x0025;
 
     /**
+     * Lens type.
+     * <p>
+     * Type: ASCII.
+     */
+    int PANASONIC_LENS_TYPE                 = 0x0051;
+
+    /**
      * Macro mode.
      *  <blockquote>
      *    <table border="0" cellpadding="0">


### PR DESCRIPTION
LightZone does not handle Panasonic lens info stored in both RW2 and JPEGs very well. See #200. There are a couple of issues casuing this:

- The specific EXIF TagID in Panasonic maker notes was not implemented yet
- a bug in the maker note probe code prevents any maker note from being triggered at all
- the offset, hardcoded in the Panasonic maker notes was incorrectly set, causing all more-than-4-byte values to be garbage (null in my case)
- Panasonic camera's hide the maker notes only in the EXIF of an embedded thumbnail, not in the RW2 TIFF IFD.

I have fixed all four issues in the PR, and it seems to load RW2's and JPEG's correclt, with lens info. Added bonus: the exported JPEG's contain a proper XMP header for my lens.